### PR TITLE
Fix dangling pointer upon mounts capacity expand

### DIFF
--- a/assetsys.h
+++ b/assetsys.h
@@ -5897,6 +5897,14 @@ assetsys_error_t assetsys_mount( assetsys_t* sys, char const* path, char const* 
         memcpy( new_mounts, sys->mounts, sizeof( *sys->mounts ) * sys->mounts_count );
         ASSETSYS_FREE( sys->memctx, sys->mounts );
         sys->mounts = new_mounts;
+        for (i = 0; i < sys->mounts_count; ++i) 
+            {
+            mount_ptr = sys->mounts + i;
+            if (mount_ptr->type == ASSETSYS_INTERNAL_MOUNT_TYPE_ZIP) 
+                {
+                mount_ptr->zip.m_pIO_opaque = &mount_ptr->zip;
+                }
+            }
         }
 
     struct assetsys_internal_mount_t* mount = &sys->mounts[ sys->mounts_count ];


### PR DESCRIPTION
While trying to fetch a file from a mounter zip archive, whilst having mounted more than __16__ zip archives (16 is initial `sys.mounts_capacity` value, after which `sys.mounts` reallocation happens), the crash would occur.

`m_pIO_opaque` is an internal field of `mz_zip_archive` struct, that points to the zip structure itself(ie. `&zip == zip.m_pIO_opaque`). It is being used in zip reading/writing handlers.

Now, when mount capacity is expanded, and all mounts are copied over the new place, `m_pIO_opaque` will keep pointing to the old zip archive struct address, and after the old `mounts` locations gets freed, it becomes a dangling pointer. Upon fetching file from the zip, the crash occurs, because minizip will use the field to read the data, but the field will contain the garbage.

I am not entirely sure if that's the best way to fix that, but there is no minizip utility to update the pointer, but re-initializing each archive again. It's a bit hacky, but hey, better than nothing!

Also i would like to suggest adding a way to set an initial mounts capacity value, for instance through the macros constant `ASSETSYS_MOUNTS_INITIAL_CAPACITY 16` or something. I need to mount whole bunch of archives (and directories), and it would be better to have ability to allocate a bigger capacity on the initialization.